### PR TITLE
 fix error message "unbound variables"

### DIFF
--- a/esh
+++ b/esh
@@ -206,7 +206,7 @@ BEGIN {
 	depth = 0
 
 	puts("#!" (SHELL ~ /\// ? SHELL : "/usr/bin/env " SHELL))
-	puts("set -eu")
+	puts("set -e")
 	puts("if ( set -o pipefail 2>/dev/null ); then set -o pipefail; fi")
 	puts("__print() { printf '%s' \"$*\"; }")
 


### PR DESCRIPTION
Remove the set option  "-u" in  BEGIN  module of AWK_CONVERTER , it causes the conversion to fail when we doesn't initialize variables in the template.